### PR TITLE
refactor: 이미지 정렬 스타일 정돈

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -278,38 +278,25 @@ body {
 }
 
 /* Center/right aligned images when alignment is set on parent paragraph */
-.prose-custom p[style*="text-align:center"] > img,
-.prose-custom p[style*="text-align: center"] > img {
+.prose-custom
+  p:where([style*="text-align:center"], [style*="text-align: center"]) > img,
+.prose-custom
+  p:where([style*="text-align:center"], [style*="text-align: center"]) + img {
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
-.prose-custom p[style*="text-align:right"] > img,
-.prose-custom p[style*="text-align: right"] > img {
+.prose-custom
+  p:where([style*="text-align:right"], [style*="text-align: right"]) > img,
+.prose-custom
+  p:where([style*="text-align:right"], [style*="text-align: right"]) + img {
   display: block;
   margin-left: auto;
 }
-.prose-custom p[style*="text-align:justify"] > img,
-.prose-custom p[style*="text-align: justify"] > img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-/* Image immediately following an aligned paragraph (common Tiptap HTML) */
-.prose-custom p[style*="text-align:center"] + img,
-.prose-custom p[style*="text-align: center"] + img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-.prose-custom p[style*="text-align:right"] + img,
-.prose-custom p[style*="text-align: right"] + img {
-  display: block;
-  margin-left: auto;
-}
-.prose-custom p[style*="text-align:justify"] + img,
-.prose-custom p[style*="text-align: justify"] + img {
+.prose-custom
+  p:where([style*="text-align:justify"], [style*="text-align: justify"]) > img,
+.prose-custom
+  p:where([style*="text-align:justify"], [style*="text-align: justify"]) + img {
   display: block;
   margin-left: auto;
   margin-right: auto;

--- a/apps/web/src/components/editor/tiptap/Toolbar.tsx
+++ b/apps/web/src/components/editor/tiptap/Toolbar.tsx
@@ -185,14 +185,15 @@ export default function Toolbar({ editor }: ToolbarProps) {
     }
   };
 
-  const setAlign = (align: 'left' | 'center' | 'right' | 'justify') => () => {
-    const chain = editor.chain().focus();
-    if (editor.isActive('image')) {
-      chain.updateAttributes('image', { textAlign: align }).run();
-    } else {
-      chain.setTextAlign(align).run();
-    }
-  };
+  const setAlign = (align: 'left' | 'center' | 'right' | 'justify') =>
+    toggle(() => {
+      const chain = editor.chain().focus();
+      if (editor.isActive('image')) {
+        chain.updateAttributes('image', { textAlign: align }).run();
+      } else {
+        chain.setTextAlign(align).run();
+      }
+    });
 
   return (
     <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- 동일한 정렬 규칙을 `:where` 구문으로 묶어 에디터/포스트 본문 이미지 정렬 CSS를 간결하게 다듬었습니다.
- 정렬 버튼 핸들러가 기존 `toggle` 래퍼를 재사용하도록 바꿔 이미지 정렬 업데이트 로직을 다른 툴바 동작과 일관되게 정리했습니다.

## Testing
- 테스트를 실행하지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_68d3bea58d78832690a19f86bcf0c27d